### PR TITLE
Add GEBCO surface (bootstrap) data.

### DIFF
--- a/doc/api/open.rst
+++ b/doc/api/open.rst
@@ -7,16 +7,8 @@ Input - ``hyoga.open``
 .. automodule:: hyoga.open
 .. currentmodule:: hyoga.open
 
-Opening example data
---------------------
-
-.. autosummary::
-   :toctree: generated/
-
-   example
-
-Opening local datasets
-----------------------
+Opening local data
+------------------
 
 .. autosummary::
    :toctree: generated/
@@ -24,6 +16,17 @@ Opening local datasets
    dataset
    mfdataset
    subdataset
+
+
+Opening online data
+-------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   bootstrap
+   example
+
 
 Opening vector data
 -------------------

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -47,7 +47,7 @@ v0.3.x Inputs
 -------------
 
 - |-| :func:`hyoga.open.atmosphere`
-- |-| :func:`hyoga.open.surface`
+- |-| :func:`hyoga.open.bootstrap`
 - |-| :func:`hyoga.open.timeseries`
 
 v0.2.x Cartography

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -47,7 +47,7 @@ v0.3.x Inputs
 -------------
 
 - |-| :func:`hyoga.open.atmosphere`
-- |-| :func:`hyoga.open.bootstrap`
+- |x| :func:`hyoga.open.bootstrap`
 - |-| :func:`hyoga.open.timeseries`
 
 v0.2.x Cartography

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -21,6 +21,17 @@
 What's new
 ==========
 
+.. _v0.3.0:
+
+v0.3.0 (unreleased)
+-------------------
+
+New features
+~~~~~~~~~~~~
+
+- Add :func:`hyoga.open.bootstrap` to open global elevation data from GEBCO as
+  bootstrapping data for PISM (:issue:`1`, :pull:`51`).
+
 .. _v0.2.2:
 
 v0.2.2 (16 Dec. 2022)

--- a/hyoga/open/__init__.py
+++ b/hyoga/open/__init__.py
@@ -5,15 +5,15 @@
 Hyoga input tools to open glacier modelling datasets.
 """
 
+from .bootstrap import bootstrap
 from .example import example
 from .local import dataset, mfdataset, subdataset
 from .naturalearth import natural_earth
 from .paleoglaciers import paleoglaciers
-from .surface import surface
 
 __all__ = [
+    'bootstrap',
     'example',
     'dataset', 'mfdataset', 'subdataset',
     'natural_earth',
-    'paleoglaciers',
-    'surface']
+    'paleoglaciers']

--- a/hyoga/open/__init__.py
+++ b/hyoga/open/__init__.py
@@ -9,9 +9,11 @@ from .example import example
 from .local import dataset, mfdataset, subdataset
 from .naturalearth import natural_earth
 from .paleoglaciers import paleoglaciers
+from .surface import surface
 
 __all__ = [
     'example',
     'dataset', 'mfdataset', 'subdataset',
     'natural_earth',
-    'paleoglaciers']
+    'paleoglaciers',
+    'surface']

--- a/hyoga/open/bootstrap.py
+++ b/hyoga/open/bootstrap.py
@@ -22,8 +22,9 @@ def _download_gebco():
     return filepath
 
 
-def surface(crs, extent, resolution=1e3):
-    """Open online surface (bootstrapping) data.
+def bootstrap(crs, extent, resolution=1e3):
+    """
+    Open bootstrapping data from online datasets for PISM.
 
     Currently a single dataset (GEBCO) is supported.
 
@@ -43,7 +44,8 @@ def surface(crs, extent, resolution=1e3):
     -------
     ds : Dataset
         The resulting dataset containing surface variables with the requested
-        ``crs``, ``extent``, and ``resolution``.
+        ``crs``, ``extent``, and ``resolution``. Use ``ds.to_netcdf()`` to
+        export as PISM bootstrapping file.
     """
 
     # open global data (use decode_coords='all' to read grid_mapping attribute)

--- a/hyoga/open/downloader.py
+++ b/hyoga/open/downloader.py
@@ -135,7 +135,8 @@ class ArchiveDownloader(CacheDownloader):
 
         # save archive as named online
         outdir, basename = os.path.split(path)
-        archivepath = os.path.join(outdir, url.split('/')[-1])
+        # FIXME GEBCO arvhive is just named 'zip'
+        archivepath = os.path.join(outdir, url.rstrip('/').split('/')[-1])
 
         # download it only if missing
         if not super().check(archivepath):

--- a/hyoga/open/downloader.py
+++ b/hyoga/open/downloader.py
@@ -73,10 +73,15 @@ class Downloader:
         # create directory if missing
         os.makedirs(os.path.dirname(path), exist_ok=True)
 
-        # download file
-        with open(path, 'wb') as binaryfile:
+        # open url and raise any http error
+        with requests.get(url, stream=True, timeout=5) as request:
+            request.raise_for_status()
+
+            # download file chunks
             print(f"downloading {url}...")
-            binaryfile.write(requests.get(url, timeout=5).content)
+            with open(path, 'wb') as binaryfile:
+                for chunk in request.iter_content(chunk_size=1024**2):
+                    binaryfile.write(chunk)
 
 
 class CacheDownloader(Downloader):

--- a/hyoga/open/downloader.py
+++ b/hyoga/open/downloader.py
@@ -147,8 +147,27 @@ class ArchiveDownloader(CacheDownloader):
         raise NotImplementedError("This should be implemented in subclasses.")
 
 
+class ZipDownloader(ArchiveDownloader):
+    """
+    Download a zip archive and extract a single file.
+
+    Call parameters
+    ---------------
+    url : str
+        The url of the file to download
+    path : str
+        The path of the extracted file relative to the cache directory.
+    member : str, optional
+        Member file to extract from , default to the basename of ``path``.
+    """
+
+    def deflate(self, archivepath, member, outdir):
+        with zipfile.ZipFile(archivepath, 'r') as archive:
+            archive.extract(member, path=outdir)
+
+
 class ShapeZipDownloader(ArchiveDownloader):
-    """A downloader that extract shapefiles and metafiles from zip archives.
+    """A downloader that extracts shapefiles and metafiles from zip archives.
 
     Call parameters
     ---------------

--- a/hyoga/open/surface.py
+++ b/hyoga/open/surface.py
@@ -35,6 +35,9 @@ def surface(crs, extent, resolution=1e3):
     ds = ds.rio.reproject(crs, resolution=resolution)
     ds = ds.rio.clip_box(west, south, east, north)
 
+    # flip data to increasing y-coord (needed by PISM)
+    ds = ds.isel(y=slice(None, None, -1))
+
     # set better standard name
     ds.elevation.attrs.update(standard_name='bedrock_altitude')
 

--- a/hyoga/open/surface.py
+++ b/hyoga/open/surface.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022, Julien Seguinot (juseg.github.io)
+# GNU General Public License v3.0+ (https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+This module contains a function to open surface-level bootstrapping datasets
+for predefined domains, including altitude, ice thickness and geothermal heat
+flux data.
+"""
+
+import xarray as xr
+import rioxarray  # noqa pylint: disable=unused-import
+
+import hyoga.open.downloader
+
+
+def _download_gebco():
+    """Download GEBCO sub-ice bathymetric and topographic data."""
+    downloader = hyoga.open.downloader.ZipDownloader()
+    filepath = downloader(
+        'https://www.bodc.ac.uk/data/open_download/gebco/'
+        'gebco_2022_sub_ice_topo/zip/', 'gebco/GEBCO_2022_sub_ice_topo.nc')
+    return filepath
+
+
+def surface(crs, extent, resolution=1e3):
+    """Open online surface data."""
+
+    # open global data
+    filepath = _download_gebco()
+    ds = xr.open_dataset(filepath)
+    ds = ds.rio.write_crs(ds.crs.epsg_code)
+
+    # clip, reproject and clip again
+    west, east, south, north = extent
+    ds = ds.rio.clip_box(west, south, east, north, crs=crs)
+    ds = ds.rio.reproject(crs, resolution=resolution)
+    ds = ds.rio.clip_box(west, south, east, north)
+
+    # set better standard name
+    ds.elevation.attrs.update(standard_name='bedrock_altitude')
+
+    # return projected dataset
+    return ds

--- a/hyoga/open/surface.py
+++ b/hyoga/open/surface.py
@@ -23,7 +23,28 @@ def _download_gebco():
 
 
 def surface(crs, extent, resolution=1e3):
-    """Open online surface data."""
+    """Open online surface (bootstrapping) data.
+
+    Currently a single dataset (GEBCO) is supported.
+
+    Parameters
+    ----------
+    crs : str
+        Coordinate reference system for the resulting dataset as OGC WKT or
+        Proj.4 string, will be passed to Dataset.rio.reproject.
+    extent : (west, east, south, north)
+        Extent for the resulting dataset in projected coordinates given by
+        ``crs``, will be passed to Dataset.rio.clip_box.
+    resolution : float, optional
+        Resolution for the output dataset in projected coordinates given by
+        ``crs``, will be passed to Dataset.rio.reproject.
+
+    Returns
+    -------
+    ds : Dataset
+        The resulting dataset containing surface variables with the requested
+        ``crs``, ``extent``, and ``resolution``.
+    """
 
     # open global data (use decode_coords='all' to read grid_mapping attribute)
     filepath = _download_gebco()

--- a/hyoga/open/surface.py
+++ b/hyoga/open/surface.py
@@ -25,10 +25,9 @@ def _download_gebco():
 def surface(crs, extent, resolution=1e3):
     """Open online surface data."""
 
-    # open global data
+    # open global data (use decode_coords='all' to read grid_mapping attribute)
     filepath = _download_gebco()
-    ds = xr.open_dataset(filepath)
-    ds = ds.rio.write_crs(ds.crs.epsg_code)
+    ds = xr.open_dataset(filepath, decode_coords='all')
 
     # clip, reproject and clip again
     west, east, south, north = extent

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     geopandas
     matplotlib
     requests
+    rioxarray
     scipy
     xarray
 python_requires = >=3.8


### PR DESCRIPTION
Add a function to download, cache, and open global elevation data from [GEBCO](https://www.gebco.net) in custom projection, extent and resolution, which can be exported as PISM bootstrapping file.