### PR TITLE
Add CHELSA atmospheric data.

### DIFF
--- a/doc/api/open.rst
+++ b/doc/api/open.rst
@@ -24,6 +24,7 @@ Opening online data
 .. autosummary::
    :toctree: generated/
 
+   atmosphere
    bootstrap
    example
 

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -46,7 +46,7 @@ v0.4.x Domains
 v0.3.x Inputs
 -------------
 
-- |-| :func:`hyoga.open.atmosphere`
+- |x| :func:`hyoga.open.atmosphere`
 - |x| :func:`hyoga.open.bootstrap`
 - |-| :func:`hyoga.open.timeseries`
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -31,6 +31,8 @@ New features
 
 - Add :func:`hyoga.open.bootstrap` to open global elevation data from GEBCO as
   bootstrapping data for PISM (:issue:`1`, :pull:`51`, :issue:`54`, pull:`55`).
+- Add :func:`hyoga.open.atmosphere` to open monthly climatologies from CHELSA
+  as atmospheric data for PISM (:issue:`3`, :pull:`56`).
 
 .. _v0.2.2:
 

--- a/hyoga/open/__init__.py
+++ b/hyoga/open/__init__.py
@@ -5,11 +5,11 @@
 Hyoga input tools to open glacier modelling datasets.
 """
 
-from .bootstrap import bootstrap
 from .example import example
 from .local import dataset, mfdataset, subdataset
 from .naturalearth import natural_earth
 from .paleoglaciers import paleoglaciers
+from .reprojected import bootstrap
 
 __all__ = [
     'bootstrap',

--- a/hyoga/open/__init__.py
+++ b/hyoga/open/__init__.py
@@ -9,10 +9,10 @@ from .example import example
 from .local import dataset, mfdataset, subdataset
 from .naturalearth import natural_earth
 from .paleoglaciers import paleoglaciers
-from .reprojected import bootstrap
+from .reprojected import atmosphere, bootstrap
 
 __all__ = [
-    'bootstrap',
+    'atmosphere', 'bootstrap',
     'example',
     'dataset', 'mfdataset', 'subdataset',
     'natural_earth',

--- a/hyoga/open/reprojected.py
+++ b/hyoga/open/reprojected.py
@@ -91,7 +91,49 @@ def _reproject_data_array(da, crs, extent, resolution):
 
 
 def atmosphere(crs, extent, resolution=1e3):
-    """Open atmospheric data from online datasets for PISM."""
+    """
+    Open atmospheric data from online datasets for PISM.
+
+    Currently a single dataset (CHELSA) is supported.
+
+    Parameters
+    ----------
+    crs : str
+        Coordinate reference system for the resulting dataset as OGC WKT or
+        Proj.4 string, will be passed to Dataset.rio.reproject.
+    extent : (west, east, south, north)
+        Extent for the resulting dataset in projected coordinates given by
+        ``crs``, will be passed to Dataset.rio.clip_box.
+    resolution : float, optional
+        Resolution for the output dataset in projected coordinates given by
+        ``crs``, will be passed to Dataset.rio.reproject.
+
+    Returns
+    -------
+    ds : Dataset
+        The resulting dataset containing surface variables with the requested
+        ``crs``, ``extent``, and ``resolution``. Use ``ds.to_netcdf()`` to
+        export as PISM bootstrapping file.
+
+    Notes
+    -----
+
+    The **calendar** is set to 'noleap'. The 365-day year is divided into
+    twelve unequal months, including a 28-day February month. This the default
+    calendar in PISM. Other calendars could be added in future versions.
+
+    To avoid ambiguity, **time units** are set to 'days'. A Udunits 'year' is
+    always 365.242198781 days, not a calendar year. A Udunits 'month' is one
+    twelfth of that, not a calendar month. In addition, Python's ``cftime``
+    (and thus xarray) does not understand the unit '365 days'.
+
+    Similarly, precipitation rates are converted to daily. According to CHELSA
+    docs monthly climatologies "represent averages for the calendar month". The
+    1981--2010 period contains 6 leap years over 30 years, so the average
+    February lasts 28.2 days. Due to the no-leap calendar, February
+    precipitations are condensed over a slightly shorter period of 28 days,
+    which overestimates daily rates. However, the total amount is unaffected.
+    """
 
     # open reprojected online data
     temp = _open_climatology(variable='tas')

--- a/hyoga/open/reprojected.py
+++ b/hyoga/open/reprojected.py
@@ -18,11 +18,29 @@ import hyoga.open.downloader
 
 def _open_elevation(source='gebco'):
     """Open elevation data (bedrock or surface) from online source."""
-    downloader = hyoga.open.downloader.ZipDownloader()
-    filepath = downloader(
-        'https://www.bodc.ac.uk/data/open_download/gebco/'
-        'gebco_2022_sub_ice_topo/zip/', 'gebco/GEBCO_2022_sub_ice_topo.nc')
-    da = xr.open_dataarray(filepath, decode_coords='all', decode_cf=True)
+
+    # GEBCO global elevation data
+    if source == 'gebco':
+        downloader = hyoga.open.downloader.ZipDownloader()
+        path = downloader(
+            'https://www.bodc.ac.uk/data/open_download/gebco/'
+            'gebco_2022_sub_ice_topo/zip/', 'gebco/GEBCO_2022_sub_ice_topo.nc')
+        da = xr.open_dataarray(path, decode_coords='all', decode_cf=True)
+
+    # CHELSA climate data input DEM
+    elif source == 'chelsa':
+        downloader = hyoga.open.downloader.CacheDownloader()
+        path = downloader(
+            'https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V2/'
+            'GLOBAL/input/dem_latlong.nc', 'chelsa/dem_latlong.nc')
+        da = xr.open_dataarray(path, decode_coords='all')
+        da = da.isel(lat=slice(None, None, -1))
+
+    # invalid sources
+    else:
+        raise ValueError(f'{source} is not a valid elevation data source.')
+
+    # return selected data array
     return da
 
 

--- a/hyoga/open/reprojected.py
+++ b/hyoga/open/reprojected.py
@@ -133,6 +133,18 @@ def atmosphere(crs, extent, resolution=1e3):
     February lasts 28.2 days. Due to the no-leap calendar, February
     precipitations are condensed over a slightly shorter period of 28 days,
     which overestimates daily rates. However, the total amount is unaffected.
+
+    Future parameters
+    -----------------
+    domain : str, optional
+        Modelling domain defining geographic projection and extent.
+    temperature : 'chelsa', optional
+        Near-surface air temperature data source, default to 'chelsa'.
+    precipitation : 'chelsa', optional
+        Precipitation rate data source, default to same as temperature.
+    elevation : 'chelsa', optional
+        Surface elevation for time-lapse corrections, default to same as
+        temperature.
     """
 
     # open reprojected online data
@@ -203,6 +215,15 @@ def bootstrap(crs, extent, resolution=1e3):
         The resulting dataset containing surface variables with the requested
         ``crs``, ``extent``, and ``resolution``. Use ``ds.to_netcdf()`` to
         export as PISM bootstrapping file.
+
+    Future parameters
+    -----------------
+    surface : 'gebco', optional
+        Name of ice surface altitude dataset, default to 'gebco'.
+    geoflux : ?, optional
+        Name of geothermal heat flux dataset, default to none?
+    thickness : ?, optional
+        Name of ice thickess dataset, default to none?
     """
 
     # open reprojected elevation data

--- a/hyoga/open/reprojected.py
+++ b/hyoga/open/reprojected.py
@@ -2,9 +2,10 @@
 # GNU General Public License v3.0+ (https://www.gnu.org/licenses/gpl-3.0.txt)
 
 """
-This module contains a function to open surface-level bootstrapping datasets
-for predefined domains, including altitude, ice thickness and geothermal heat
-flux data.
+This module contain function to open reprojected raster from online sources
+stored in the hyoga cache directory. The resulting datasets can be exported as
+PISM input files (bootstrapping and atmosphere files) using `ds.to_netcdf()`.
+Geographic reprojection is handled by rioxarray.
 """
 
 import affine

--- a/hyoga/open/reprojected.py
+++ b/hyoga/open/reprojected.py
@@ -16,6 +16,14 @@ import rioxarray  # noqa pylint: disable=unused-import
 import hyoga.open.downloader
 
 
+def _clear_scaling_attributes(ds):
+    """Clear scaled encoding attributes not understood by PISM."""
+    for var in ds.data_vars.values():
+        var.encoding.pop('add_offset', None)
+        var.encoding.pop('scale_factor', None)
+        var.encoding.pop('dtype', None)
+
+
 def _open_elevation(source='gebco'):
     """Open elevation data (bedrock or surface) from online source."""
 
@@ -122,6 +130,9 @@ def atmosphere(crs, extent, resolution=1e3):
         long_name='ice surface altitude',
         standard_name='surface_altitude', units='m')
 
+    # clear scaling attributes
+    _clear_scaling_attributes(ds)
+
     # return projected dataset
     return ds
 
@@ -159,5 +170,9 @@ def bootstrap(crs, extent, resolution=1e3):
     # set better standard name
     da.attrs.update(standard_name='bedrock_altitude')
 
-    # return as dataset
-    return da.to_dataset()
+    # convert to dataset and clear scaling
+    ds = da.to_dataset()
+    _clear_scaling_attributes(ds)
+
+    # return projected dataset
+    return ds


### PR DESCRIPTION
Add a function to download, cache, and open monthly climatologies from [CHELSA](https://www.chelsa-climate.org) in custom projection, extent and resolution, which can be exported as PISM atmosphere file.