### PR TITLE
Workaround scipy 1.10.0 issue 17718.

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -34,6 +34,12 @@ New features
 - Add :func:`hyoga.open.atmosphere` to open monthly climatologies from CHELSA
   as atmospheric data for PISM (:issue:`3`, :pull:`56`).
 
+Bug fixes
+~~~~~~~~~
+
+- Add workaround for scipy 0.10.0 bug in profile interpolation with mixed data
+  types (https://github.com/scipy/scipy/issues/17718, :issue:`58`, :pr:`59`).
+
 .. _v0.2.2:
 
 v0.2.2 (16 Dec. 2022)

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -38,7 +38,7 @@ Bug fixes
 ~~~~~~~~~
 
 - Add workaround for scipy 0.10.0 bug in profile interpolation with mixed data
-  types (https://github.com/scipy/scipy/issues/17718, :issue:`58`, :pr:`59`).
+  types (https://github.com/scipy/scipy/issues/17718, :issue:`58`, :pull:`59`).
 
 .. _v0.2.2:
 


### PR DESCRIPTION
Convert all data to `float64` during profile interpolation if `scipy==1.10.0` is in use. This could significantly affect memory load on large arrays. Behavior remains unchanged on other scipy versions, and interpolated data is always returned in original precision. This PR assumes the bug will be fixed in `scipy>0.10.0`. See scipy/scipy#17718. Close #58.