### PR TITLE
Fix reprojection with resolution increase.

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -43,7 +43,7 @@ New features
 
 - Add :func:`hyoga.open.bootstrap` to open global elevation data from either
   GEBCO or CHELSA as bootstrapping data for PISM (:issue:`1`, :pull:`51`,
-  :issue:`54`, :pull:`55`, :issue:`57`, :pull:`60`, :pull:`62`).
+  :issue:`54`, :pull:`55`, :issue:`57`, :pull:`60`, :pull:`62`, :pull:`64`).
 - Add :func:`hyoga.open.atmosphere` to open monthly climatologies from CHELSA
   as atmospheric data for PISM (:issue:`3`, :pull:`56`).
 

--- a/hyoga/open/reprojected.py
+++ b/hyoga/open/reprojected.py
@@ -87,8 +87,13 @@ def _reproject_data_array(da, crs, bounds, resolution):
     west, south, east, north = bounds
     transform = affine.Affine(resolution, 0, west, 0, resolution, south)
 
+    # compute output shape
+    cols = int((east-west)/resolution)
+    rows = int((north-south)/resolution)
+    shape = (rows, cols)
+
     # reproject to new crs
-    da = da.rio.reproject(crs, transform=transform, resampling=1)
+    da = da.rio.reproject(crs, transform=transform, resampling=1, shape=shape)
 
     # clip to exact bounds
     da = da.rio.clip_box(*bounds)

--- a/hyoga/open/reprojected.py
+++ b/hyoga/open/reprojected.py
@@ -95,9 +95,6 @@ def _reproject_data_array(da, crs, bounds, resolution):
     # reproject to new crs
     da = da.rio.reproject(crs, transform=transform, resampling=1, shape=shape)
 
-    # clip to exact bounds
-    da = da.rio.clip_box(*bounds)
-
     # return reprojected data
     return da
 

--- a/hyoga/open/reprojected.py
+++ b/hyoga/open/reprojected.py
@@ -79,13 +79,21 @@ def _open_climatology(source='chelsa', variable='tas'):
 
 def _reproject_data_array(da, crs, bounds, resolution):
     """Reproject data array to exact bounds via affine transform."""
+
+    # clip around target bounds
     da = da.rio.clip_box(crs=crs, *bounds)
-    transform_bounds = da.rio.transform_bounds(crs)
-    xoffset = transform_bounds[0] - transform_bounds[0] % resolution
-    yoffset = transform_bounds[1] - transform_bounds[1] % resolution
-    transform = affine.Affine(resolution, 0, xoffset, 0, resolution, yoffset)
+
+    # compute affine transform
+    west, south, east, north = bounds
+    transform = affine.Affine(resolution, 0, west, 0, resolution, south)
+
+    # reproject to new crs
     da = da.rio.reproject(crs, transform=transform, resampling=1)
+
+    # clip to exact bounds
     da = da.rio.clip_box(*bounds)
+
+    # return reprojected data
     return da
 
 


### PR DESCRIPTION
This fixes a bug where bootstrap and atmosphere data were cropped when reprojected with an increased resolution relative to the original (i.e. < 1km for CHELSA data).