### PR TITLE
Speedup atmosphere datasets with dask.

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -26,6 +26,13 @@ What's new
 v0.3.1 (unreleased)
 -------------------
 
+Bug fixes
+~~~~~~~~~
+
+- Add missing optional dependency to dask_ (:issue:`73`, :pull:`76`).
+
+.. _dask: https://www.dask.org
+
 Internal changes
 ~~~~~~~~~~~~~~~~
 

--- a/hyoga/open/reprojected.py
+++ b/hyoga/open/reprojected.py
@@ -66,7 +66,8 @@ def _open_climatology(source='chelsa', variable='tas'):
             f'GLOBAL/climatologies/1981-2010/{variable}/{basename}',
             f'chelsa/{basename}') for basename in basenames)
         ds = xr.open_mfdataset(
-            paths, combine='nested', concat_dim='time', decode_cf=True)
+            paths, combine='nested', concat_dim='time', chunks={'y': 120},
+            decode_cf=True)
         da = ds.band_data.squeeze()
 
     # invalid sources

--- a/hyoga/open/reprojected.py
+++ b/hyoga/open/reprojected.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Julien Seguinot (juseg.github.io)
+# Copyright (c) 2022-2024, Julien Seguinot (juseg.dev)
 # GNU General Public License v3.0+ (https://www.gnu.org/licenses/gpl-3.0.txt)
 
 """
@@ -66,8 +66,7 @@ def _open_climatology(source='chelsa', variable='tas'):
             f'GLOBAL/climatologies/1981-2010/{variable}/{basename}',
             f'chelsa/{basename}') for basename in basenames)
         ds = xr.open_mfdataset(
-            paths, combine='nested', concat_dim='time', chunks={'y': 120},
-            decode_cf=True)
+            paths, combine='nested', concat_dim='time', decode_cf=True)
         da = ds.band_data.squeeze()
 
     # invalid sources

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
 packages = find:
 install_requires =
     cf_xarray
+    dask
     geopandas
     matplotlib
     requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
 packages = find:
 install_requires =
     cf_xarray<0.8.0
-    dask
     geopandas
     matplotlib
     requests
@@ -40,6 +39,8 @@ docs =
     sphinx-autosummary-accessors
     sphinx-book-theme>=0.3.3
     sphinx-gallery
+open =
+    dask
 
 [flake8]
 exclude = .git,__pycache__,_build,doc/conf.py


### PR DESCRIPTION
Add dask as a missing dependency (always needed by `open_mfdataset`) and chunk global data greatly reducing in-memory load. Close #74.