### PR TITLE
Add Python 3.11 and 3.12 in test workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2021-2023, Julien Seguinot (juseg.github.io)
+.. Copyright (c) 2021-2024, Julien Seguinot (juseg.dev)
 .. GNU General Public License v3.0+ (https://www.gnu.org/licenses/gpl-3.0.txt)
 
 .. currentmodule:: hyoga
@@ -20,6 +20,16 @@
 
 What's new
 ==========
+
+.. _v0.3.1:
+
+v0.3.1 (unreleased)
+-------------------
+
+Internal changes
+~~~~~~~~~~~~~~~~
+
+- Test (and support) Python 3.11 and 3.12 (:pull:`77`).
 
 .. _v0.3.0:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, Julien Seguinot (juseg.github.io)
+# Copyright (c) 2019-2024, Julien Seguinot (juseg.dev)
 # GNU General Public License v3.0+ (https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # Build config for hyoga
@@ -22,7 +22,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    cf_xarray
+    cf_xarray<0.8.0
     geopandas
     matplotlib
     requests


### PR DESCRIPTION
- [x] Check that old tests run on newer packages.
- [x] Add Python 3.11 in GitHub test workflow.
- [x] Add Python 3.12 in GitHub test workflow.