### PR TITLE
Rename grid_mapping in reprojected data.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ python:
 
 # Set the version of Python and other tools you might need
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.12"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ python:
 
 # Set the version of Python and other tools you might need
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-20.04"
   tools:
-    python: "3.12"
+    python: "3.8"

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -36,8 +36,14 @@ Bug fixes
 
 - Add missing optional dependency to dask_ (:issue:`74`, :pull:`76`).
 - Fix incompatibility with cf_xarray_ 0.8.0 (:issue:`73`, :pull:`78`).
+- Fix multiple mappings in reprojected datasets (:issue:`72`, :pull:`81`).
 
 .. _dask: https://www.dask.org
+
+Documentation
+~~~~~~~~~~~~~
+
+- Fix build errors, warnings, outdated credits (:issue:`79`, :pull:`80`).
 
 Internal changes
 ~~~~~~~~~~~~~~~~

--- a/hyoga/open/reprojected.py
+++ b/hyoga/open/reprojected.py
@@ -95,6 +95,10 @@ def _reproject_data_array(da, crs, bounds, resolution):
     # reproject to new crs
     da = da.rio.reproject(crs, transform=transform, resampling=1, shape=shape)
 
+    # rename grid_mapping to avoid different values in datasets (#72)
+    da = da.rename({da.encoding['grid_mapping']: 'spatial_ref'})
+    da.encoding.update(grid_mapping='spatial_ref')
+
     # return reprojected data
     return da
 

--- a/hyoga/open/reprojected.py
+++ b/hyoga/open/reprojected.py
@@ -146,6 +146,9 @@ def atmosphere(crs, bounds, resolution=1e3):
     February lasts 28.2 days. Due to the no-leap calendar, February
     precipitations are condensed over a slightly shorter period of 28 days,
     which overestimates daily rates. However, the total amount is unaffected.
+
+    Any **grid_mapping** variable in the source data will be renamed to
+    'spatial_ref' to avoid returning a dataset with multiple grid mappings.
     """
 
     # future parameters:
@@ -229,6 +232,12 @@ def bootstrap(crs, bounds, bedrock='gebco', resolution=1e3):
         The resulting dataset containing surface variables with the requested
         ``crs``, ``bounds``, and ``resolution``. Use ``ds.to_netcdf()`` to
         export as PISM bootstrapping file.
+
+    Notes
+    -----
+
+    Any **grid_mapping** variable in the source data will be renamed to
+    'spatial_ref' to avoid returning a dataset with multiple grid mappings.
     """
 
     # future parameters


### PR DESCRIPTION
Always rename grid_mapping to `'spatial_ref'` in reprojected data. This avoids multiple (identical) mappings in datasets containing variables from different sources. It allows plotting vectors on these datasets. The only case for now concerns atmosphere data.

```python
domain = {'crs':  'epsg:32632', 'bounds': [150e3, 4820e3, 1050e3, 5420e3]}
with hyoga.open.atmosphere(**domain) as ds:
    ds.hyoga.plot.surface_hillshade()
    ds.hyoga.plot.paleoglaciers(alpha=0.75)
```

As an added bonus, `to_netcdf()` files should be GDAL-compatible (untested). Close #72.