### PR TITLE
Upgrade Python on Read the Docs.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ python:
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.11"
+    python: '3.12'

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ python:
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.8"
+    python: "3.9"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ python:
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.9"
+    python: "3.10"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ python:
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.10"
+    python: "3.11"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ python:
 
 # Set the version of Python and other tools you might need
 build:
-  os: "ubuntu-20.04"
+  os: 'ubuntu-22.04'
   tools:
     python: '3.12'

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -43,7 +43,7 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- Fix build errors, warnings, outdated credits (:issue:`79`, :pull:`80`).
+- Fix build errors, warnings, credits (:issue:`79`, :pull:`80`, :pull:`82`).
 
 Internal changes
 ~~~~~~~~~~~~~~~~

--- a/examples/interp/plot_interpolated_surface.py
+++ b/examples/interp/plot_interpolated_surface.py
@@ -21,8 +21,8 @@ ax = plt.subplot()
 with hyoga.open.example('pism.alps.out.2d.nc') as ds:
 
     # compute surface altitude and remove bedrock altitude
-    ds['usurf'] = ds.hyoga.getvar('surface_altitude')
-    ds = ds.drop('topg')
+    ds = ds.hyoga.assign(surface_altitude=ds.hyoga.getvar('surface_altitude'))
+    ds = ds.drop_vars(ds.hyoga.getvar('bedrock_altitude').name)
 
     # compute isostatic adjustment from a reference input topography
     ds = ds.hyoga.assign_isostasy(hyoga.open.example('pism.alps.in.boot.nc'))

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,19 +22,20 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    cf_xarray
+    cf_xarray>= 0.5.0  # DataArray.cf.__getitem__() with standard names.
     geopandas
     matplotlib
     requests
     rioxarray
     scipy
-    xarray
+    xarray>=0.18  # xarray.Dataset.plot.streamplot
 python_requires = >=3.9
 
 [options.extras_require]
 docs =
     contextily
     netcdf4
+    pandas<2.0
     sphinx
     sphinx-autosummary-accessors
     sphinx-book-theme>=0.3.3


### PR DESCRIPTION
Read the Docs build fails on now-unsupported Python 3.8. But it also appear to fail on Python 3.12 (#81). I can build docs locally though, so I will the Read the Docs build step-by-step in this PR.