### PR TITLE
Upgrade colormap registration to recent matplotlib.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, Julien Seguinot (juseg.dev)
+# Copyright (c) 2019-2025, Julien Seguinot (juseg.dev)
 # GNU General Public License v3.0+ (https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # Build config for hyoga
@@ -24,7 +24,7 @@ packages = find:
 install_requires =
     cf_xarray>= 0.5.0  # DataArray.cf.__getitem__() with standard names.
     geopandas
-    matplotlib
+    matplotlib <= 3.8  # cm.register_cmap()
     numpy<2
     requests
     rioxarray


### PR DESCRIPTION
- [ ] Test existing code on old versions.
- [ ] Fix compatibility with matplotlib 3.9 and newer.
- [ ] Add version check or drop support for old matplotlib.