### PR TITLE
Add compatibility with numpy >= 2

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -45,12 +45,13 @@ Breaking changes
 Bug fixes
 ~~~~~~~~~
 
-- Add newly missing requirement of ``numpy<2`` (:issue:`90`, :pull:`91`).
 - Fix CHELSA_-2.1 download urls (:issue:`103`, :pull:`104`).
 - Fix Ehlers et al. (2011) download error (:issue:`109`, :pull:`110`).
 - Add Sphinx config path in `.readthedocs.yaml` (:issue:`105`, :pull:`106`).
 - Fix broken colormap registration in some recent matplotlib versions
   (:issue:`107`, :pull:`108`).
+- Fix incompatibility with Numpy 2 and newer (:issue:`90`, :issue:`111`,
+  :pull:`91` :issue:`112`).
 
 Internal changes
 ~~~~~~~~~~~~~~~~

--- a/hyoga/plot/hillshade.py
+++ b/hyoga/plot/hillshade.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, Julien Seguinot (juseg.github.io)
+# Copyright (c) 2018-2025, Julien Seguinot (juseg.dev)
 # GNU General Public License v3.0+ (https://www.gnu.org/licenses/gpl-3.0.txt)
 
 """
@@ -6,26 +6,16 @@ Shaded relief plotting tools.
 """
 
 import numpy as np
-import xarray as xr
 
 
 def _compute_gradient(darray):
     """Compute gradient along a all dimensions of a data array."""
 
-    # extract coordinate data
-    dims = darray.dims
-    coords = [darray[d].data for d in dims]
+    # differentiate along all dimensions
+    gradient = (darray.differentiate(dim) for dim in darray.dims)
 
-    # apply numpy.gradient
-    darray = xr.apply_ufunc(np.gradient, darray, *coords,
-                            input_core_dims=(dims,)+dims,
-                            output_core_dims=[('n',)+dims])
-
-    # add vector component coordinate
-    darray = darray.assign_coords(n=list(dims))
-
-    # return as single dataarray
-    return darray
+    # return as a generator
+    return gradient
 
 
 def _compute_hillshade(darray, altitude=30.0, azimuth=315.0):

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     cf_xarray>= 0.5.0  # DataArray.cf.__getitem__() with standard names.
     geopandas
     matplotlib >= 3.5, != 3.8.0  # matplotlib.colormaps.register(), #26949
-    numpy<2
+    numpy
     requests
     rioxarray
     scipy


### PR DESCRIPTION
- [x] Refactor hillshades using `xarray.DataArray.differentiate()`.
- [x] Remove `numpy < 2` current version cap.
- [x] Document changes in `whatsnew.rst`.