### PR TITLE
Bump version (conf, setup, whatsnew) to v0.3.2.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,7 @@ project = 'hyoga'
 copyright = '2021-2024'
 author = 'Julien Seguinot'
 version = '0.3 Cocuy'
-release = '0.3.1'
+release = '0.3.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/datasets/opening.rst
+++ b/doc/datasets/opening.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2021-2022, Julien Seguinot (juseg.github.io)
+.. Copyright (c) 2021-2025, Julien Seguinot (juseg.dev)
 .. GNU General Public License v3.0+ (https://www.gnu.org/licenses/gpl-3.0.txt)
 
 Opening datasets
@@ -42,8 +42,9 @@ are ready to export as PISM input files using :meth:`.Dataset.to_netcdf`.
 
 .. warning::
 
-   Running these for the first time will download and deflate ca. 12 GB data
-   from the web. Broken or partially downloaded files are not handled and will
+   Running these for the first time will download and deflate ca. 12 GB global
+   data in the default case, and ca. 1.2 TB in the case of `cw5e5` atmosphere
+   source. Broken or partially downloaded files are not handled and instead
    need to be manually deleted from the cache directory (``~/.cache/hyoga``) in
    case of interrupted downloads.
 
@@ -81,7 +82,7 @@ data can take several minutes. ::
 Both input files are now ready to be used in a simple paleo-glacier modelling
 run on the alps::
 
-   mpiexec -n 4 pismr \
+   mpiexec -n 4 pism \
        -i boot.nc -bootstrap -o run.nc -ys 0 -ye 100 \
        -atmosphere given,elevation_change \
            -atmosphere.given.periodic \

--- a/doc/datasets/opening.rst
+++ b/doc/datasets/opening.rst
@@ -43,10 +43,10 @@ are ready to export as PISM input files using :meth:`.Dataset.to_netcdf`.
 .. warning::
 
    Running these for the first time will download and deflate ca. 12 GB global
-   data in the default case, and ca. 1.2 TB in the case of `cw5e5` atmosphere
-   source. Broken or partially downloaded files are not handled and instead
-   need to be manually deleted from the cache directory (``~/.cache/hyoga``) in
-   case of interrupted downloads.
+   data in the default case, and ca. 1.2 TB in the case of ``'cw5e5'``
+   atmosphere source. Broken or partially downloaded files are not handled and
+   instead need to be manually deleted from the cache directory
+   (``~/.cache/hyoga``) in case of interrupted downloads.
 
 PISM example run
 ----------------

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -37,6 +37,11 @@ New features
 - Open atmosphere datasets in International System (SI) units; potentially a
   breaking change for non-unit-agnostic models (:issue:`94`, :pull:`113`).
 
+.. warning::
+   Support for CHELSA-W5E5 is currently experimental. It requires 1.2 terabytes
+   of free disk space for cacheing, comes with a known bug (:issue:`114`) and a
+   long to-do list of planned improvements (:issue:`95`).
+
 .. _CHELSA-W5E5: https://chelsa-climate.org/chelsa-w5e5-v1-0-daily-climate-data-at-1km-resolution/
 
 Breaking changes

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -23,7 +23,7 @@ What's new
 
 .. _v0.3.2:
 
-v0.3.2 (unreleased)
+v0.3.2 (1 Jul 2025)
 -------------------
 
 New features

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -26,7 +26,7 @@ What's new
 v0.3.2 (1 Jul 2025)
 -------------------
 
-This release brings experimental support for aggregated CHELSA_W5E5_ climate as
+This release brings experimental support for aggregated CHELSA-W5E5_ climate as
 an alternative source for atmosphere :doc:`datasets </datasets/opening>`, which
 now use SI units. Bugs were fixed repairing the download of paleoglacier vector
 data and enabling compatibility with most recent versions of Numpy, Matplotlib,

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -26,6 +26,12 @@ What's new
 v0.3.2 (1 Jul 2025)
 -------------------
 
+This release brings experimental support for aggregated CHELSA_W5E5_ climate as
+an alternative source for atmosphere :doc:`datasets </datasets/opening>`, which
+now use SI units. Bugs were fixed repairing the download of paleoglacier vector
+data and enabling compatibility with most recent versions of Numpy, Matplotlib,
+and Read the Docs. Code coverage decreased to 63 percent.
+
 New features
 ~~~~~~~~~~~~
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@
 [metadata]
 
 name = hyoga
-version = 0.3.1
+version = 0.3.2
 author = Julien Seguinot
 description = Paleoglacier modelling framework
 long_description = file: README.rst


### PR DESCRIPTION
- [x] Bump version (conf, setup, whatsnew) to v0.3.2.
- [x] Add warning on experimental CHELSA-W5E5.
- [x] Update atmosphere dataset documentation.