### PR TITLE
Remove pandas version cap to build the docs.

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -35,6 +35,9 @@ Documentation
 ~~~~~~~~~~~~~
 
 - Fix build errors and warnings (:issue:`121`, :pull:`122`).
+- Relax pandas_ version cap to build the docs (:issue:`83`, :pull:`123`).
+
+.. _pandas: https://pandas.pydata.org
 
 .. _v0.3.2:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ python_requires = >=3.9
 docs =
     contextily
     netcdf4
-    pandas<2.2.0
+    pandas != 2.2.0
     sphinx<9
     sphinx-autosummary-accessors
     sphinx-book-theme>=0.3.3


### PR DESCRIPTION
- [x] Relax docs pandas version cap.
- [x] Test building the docs on pandas 3.
- [x] Document changes in whatsnew.

Close #83.